### PR TITLE
Desktop: Resolves #41: Multi-window support in the desktop app

### DIFF
--- a/api/Joplin.d.ts
+++ b/api/Joplin.d.ts
@@ -73,5 +73,8 @@ export default class Joplin {
      */
     require(_path: string): any;
     versionInfo(): Promise<import("./types").VersionInfo>;
+    /**
+     * Tells whether the current theme is a dark one or not.
+     */
     shouldUseDarkColors(): Promise<boolean>;
 }

--- a/api/JoplinSettings.d.ts
+++ b/api/JoplinSettings.d.ts
@@ -52,11 +52,15 @@ export default class JoplinSettings {
      */
     setValue(key: string, value: any): Promise<void>;
     /**
-     * Gets a global setting value, including app-specific settings and those set by other plugins.
+     * Gets global setting values, including app-specific settings and those set by other plugins.
      *
      * The list of available settings is not documented yet, but can be found by looking at the source code:
      *
-     * https://github.com/laurent22/joplin/blob/dev/packages/lib/models/Setting.ts#L142
+     * https://github.com/laurent22/joplin/blob/dev/packages/lib/models/settings/builtInMetadata.ts
+     */
+    globalValues(keys: string[]): Promise<any[]>;
+    /**
+     * @deprecated Use joplin.settings.globalValues()
      */
     globalValue(key: string): Promise<any>;
     /**

--- a/api/JoplinViewsDialogs.d.ts
+++ b/api/JoplinViewsDialogs.d.ts
@@ -1,5 +1,5 @@
 import Plugin from '../Plugin';
-import { ButtonSpec, ViewHandle, DialogResult } from './types';
+import { ButtonSpec, ViewHandle, DialogResult, Toast } from './types';
 /**
  * Allows creating and managing dialogs. A dialog is modal window that
  * contains a webview and a row of buttons. You can update the
@@ -43,6 +43,10 @@ export default class JoplinViewsDialogs {
      * Displays a message box with OK/Cancel buttons. Returns the button index that was clicked - "0" for OK and "1" for "Cancel"
      */
     showMessageBox(message: string): Promise<number>;
+    /**
+     * Displays a Toast notification in the corner of the application screen.
+     */
+    showToast(toast: Toast): Promise<void>;
     /**
      * Displays a dialog to select a file or a directory. Same options and
      * output as

--- a/api/JoplinViewsEditor.d.ts
+++ b/api/JoplinViewsEditor.d.ts
@@ -1,5 +1,26 @@
 import Plugin from '../Plugin';
 import { ActivationCheckCallback, ViewHandle, UpdateCallback } from './types';
+export interface EditorPluginProps {
+    /** The ID of the window to show the editor plugin. Use `undefined` for the main window. */
+    windowId: string | undefined;
+    /**
+     * Called to determine whether the custom editor supports the current note.
+     */
+    onActivationCheck: ActivationCheckCallback;
+}
+export interface SaveEditorContentProps {
+    /**
+     * The ID of the note to save. This should match either:
+     * - The ID of the note currently being edited
+     * - The ID of a note that was very recently open in the editor.
+     *
+     * This property is present to ensure that the note editor doesn't write
+     * to the wrong note just after switching notes.
+     */
+    noteId: string;
+    /** The note's new content. */
+    body: string;
+}
 /**
  * Allows creating alternative note editors. You can create a view to handle loading and saving the
  * note, and do your own rendering.
@@ -46,7 +67,7 @@ export default class JoplinViewsEditors {
     /**
      * Creates a new editor view
      */
-    create(id: string): Promise<ViewHandle>;
+    create(id: string, options?: EditorPluginProps): Promise<ViewHandle>;
     /**
      * Sets the editor HTML content
      */
@@ -59,6 +80,10 @@ export default class JoplinViewsEditors {
      * See [[JoplinViewPanels]]
      */
     onMessage(handle: ViewHandle, callback: Function): Promise<void>;
+    /**
+     * Saves the content of the editor, without calling `onUpdate` for editors in the same window.
+     */
+    saveNote(handle: ViewHandle, props: SaveEditorContentProps): Promise<void>;
     /**
      * Emitted when the editor can potentially be activated - this is for example when the current
      * note is changed, or when the application is opened. At that point you should check the
@@ -73,12 +98,8 @@ export default class JoplinViewsEditors {
     onUpdate(handle: ViewHandle, callback: UpdateCallback): Promise<void>;
     /**
      * See [[JoplinViewPanels]]
-     *
-     * **Note**: `windowId`, if given, should be the ID of the window containing
-     * the target editor plugin. If not given, the message is sent to the editor
-     * in the main window (if any).
      */
-    postMessage(handle: ViewHandle, message: any, windowId?: string): void;
+    postMessage(handle: ViewHandle, message: any): void;
     /**
      * Tells whether the editor is active or not.
      */

--- a/api/JoplinViewsEditor.d.ts
+++ b/api/JoplinViewsEditor.d.ts
@@ -60,21 +60,25 @@ export default class JoplinViewsEditors {
      */
     onMessage(handle: ViewHandle, callback: Function): Promise<void>;
     /**
-     * Emitted when the editor can potentially be activated - this for example when the current note
-     * is changed, or when the application is opened. At that point should can check the current
-     * note and decide whether your editor should be activated or not. If it should return `true`,
-     * otherwise return `false`.
+     * Emitted when the editor can potentially be activated - this is for example when the current
+     * note is changed, or when the application is opened. At that point you should check the
+     * current note and decide whether your editor should be activated or not. If it should, return
+     * `true`, otherwise return `false`.
      */
     onActivationCheck(handle: ViewHandle, callback: ActivationCheckCallback): Promise<void>;
     /**
-     * Emitted when the editor content should be updated. This for example when the currently
+     * Emitted when your editor content should be updated. This is for example when the currently
      * selected note changes, or when the user makes the editor visible.
      */
     onUpdate(handle: ViewHandle, callback: UpdateCallback): Promise<void>;
     /**
      * See [[JoplinViewPanels]]
+     *
+     * **Note**: `windowId`, if given, should be the ID of the window containing
+     * the target editor plugin. If not given, the message is sent to the editor
+     * in the main window (if any).
      */
-    postMessage(handle: ViewHandle, message: any): void;
+    postMessage(handle: ViewHandle, message: any, windowId?: string): void;
     /**
      * Tells whether the editor is active or not.
      */

--- a/api/JoplinViewsPanels.d.ts
+++ b/api/JoplinViewsPanels.d.ts
@@ -80,5 +80,12 @@ export default class JoplinViewsPanels {
      * Tells whether the panel is visible or not
      */
     visible(handle: ViewHandle): Promise<boolean>;
+    /**
+     * Assuming that the current panel is an editor plugin view, returns
+     * whether the editor plugin view supports editing the current note.
+     *
+     * If `windowId` is not provided, this returns the activation state
+     * in the default window.
+     */
     isActive(handle: ViewHandle): Promise<boolean>;
 }

--- a/api/JoplinWorkspace.d.ts
+++ b/api/JoplinWorkspace.d.ts
@@ -25,6 +25,9 @@ interface NoteAlarmTriggerEvent {
 interface SyncCompleteEvent {
     withErrors: boolean;
 }
+interface WindowOpenEvent {
+    windowId: string;
+}
 type WorkspaceEventHandler<EventType> = (event: EventType) => void;
 type ItemChangeHandler = WorkspaceEventHandler<ItemChangeEvent>;
 type SyncStartHandler = () => void;
@@ -72,6 +75,14 @@ export default class JoplinWorkspace {
      */
     onSyncComplete(callback: WorkspaceEventHandler<SyncCompleteEvent>): Promise<Disposable>;
     /**
+     * Called when a secondary window is opened.
+     */
+    onWindowOpen(callback: WorkspaceEventHandler<WindowOpenEvent>): Promise<Disposable>;
+    /**
+     * Called when a secondary window is closed.
+     */
+    onWindowClose(callback: WorkspaceEventHandler<WindowOpenEvent>): Promise<Disposable>;
+    /**
      * Called just before the editor context menu is about to open. Allows
      * adding items to it.
      *
@@ -81,7 +92,7 @@ export default class JoplinWorkspace {
     /**
      * Gets the currently selected note. Will be `null` if no note is selected.
      */
-    selectedNote(): Promise<any>;
+    selectedNote(windowId?: string): Promise<any>;
     /**
      * Gets the currently selected folder. In some cases, for example during
      * search or when viewing a tag, no folder is actually selected in the user

--- a/api/types.ts
+++ b/api/types.ts
@@ -400,17 +400,13 @@ export interface Rectangle {
 export interface EditorUpdateEvent {
 	newBody: string;
 	noteId: string;
-
-	/** The ID of the window containing the plugin. */
-	windowId: string;
 }
+export type ActivationCheckCallback = (event: ActivationCheckEvent)=> Promise<boolean>;
 
 export interface ActivationCheckEvent {
 	noteId: string;
 	windowId: string;
 }
-
-export type ActivationCheckCallback = (event: ActivationCheckEvent)=> Promise<boolean>;
 export type UpdateCallback = (event: EditorUpdateEvent)=> Promise<void>;
 
 export type VisibleHandler = ()=> Promise<void>;

--- a/api/types.ts
+++ b/api/types.ts
@@ -372,6 +372,19 @@ export interface DialogResult {
 	formData?: any;
 }
 
+export enum ToastType {
+	Info = 'info',
+	Success = 'success',
+	Error = 'error',
+}
+
+export interface Toast {
+	message: string;
+	type?: ToastType;
+	duration?: number;
+	timestamp?: number;
+}
+
 export interface Size {
 	width?: number;
 	height?: number;
@@ -384,9 +397,21 @@ export interface Rectangle {
 	height?: number;
 }
 
-export type ActivationCheckCallback = ()=> Promise<boolean>;
+export interface EditorUpdateEvent {
+	newBody: string;
+	noteId: string;
 
-export type UpdateCallback = ()=> Promise<void>;
+	/** The ID of the window containing the plugin. */
+	windowId: string;
+}
+
+export interface ActivationCheckEvent {
+	noteId: string;
+	windowId: string;
+}
+
+export type ActivationCheckCallback = (event: ActivationCheckEvent)=> Promise<boolean>;
+export type UpdateCallback = (event: EditorUpdateEvent)=> Promise<void>;
 
 export type VisibleHandler = ()=> Promise<void>;
 
@@ -395,6 +420,8 @@ export interface EditContextMenuFilterObject {
 }
 
 export interface EditorActivationCheckFilterObject {
+	effectiveNoteId: string;
+	windowId: string;
 	activatedEditors: {
 		pluginId: string;
 		viewId: string;
@@ -609,6 +636,27 @@ export interface CodeMirrorControl {
 		 */
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		enableLanguageDataAutocomplete: { of: (enabled: boolean)=> any };
+
+		/**
+		 * A CodeMirror [facet](https://codemirror.net/docs/ref/#state.EditorState.facet) that contains
+		 * the ID of the note currently open in the editor.
+		 *
+		 * Access the value of this facet using
+		 * ```ts
+		 * const noteIdFacet = editorControl.joplinExtensions.noteIdFacet;
+		 * const editorState = editorControl.editor.state;
+		 * const noteId = editorState.facet(noteIdFacet);
+		 * ```
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- No better type available
+		noteIdFacet: any;
+		/**
+		 * A CodeMirror [StateEffect](https://codemirror.net/docs/ref/#state.StateEffect) that is
+		 * included in a [Transaction](https://codemirror.net/docs/ref/#state.Transaction) when the
+		 * note ID changes.
+		 */
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- No better type available
+		setNoteIdEffect: any;
 	};
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { IpcMessage, Note, settingItems, settingSectionName } from './utils/type
 import { boardsEqual, noteIsBoard, parseNote } from './utils/noteParser';
 import Logger, { TargetType } from '@joplin/utils/Logger';
 import { MenuItemLocation } from 'api/types';
-import { msleep } from './utils/time';
 import messageHandlers from './messageHandlers';
 
 const globalLogger = new Logger();
@@ -22,34 +21,14 @@ const newNoteBody = `# Backlog
 # Do not remove this block
 \`\`\``;
 
-joplin.plugins.register({
-	onStart: async function() {
-		const versionInfo = await joplin.versionInfo();
+const registerEditorPlugin = async (windowId: string|undefined) => {
+	const versionInfo = await joplin.versionInfo();
 
-		await joplin.settings.registerSection(settingSectionName, {
-			label: 'YesYouKan',
-			iconName: 'fas fa-th-list',
-		});
-		await joplin.settings.registerSettings(settingItems);
+	const editors = joplin.views.editors;
 
-		const editors = joplin.views.editors;
-
-		const view = await editors.create("kanbanBoard");
-		
-		await editors.setHtml(view, `<div id="root" class="platform-${versionInfo.platform}"></div>`);
-		await editors.addScript(view, './panel.js');
-		await editors.addScript(view, './style/reset.css');
-		await editors.addScript(view, './style/main.css');
-		await editors.addScript(view, './vendor/coloris/coloris.css');
-		await editors.addScript(view, './vendor/coloris/coloris.js');
-
-		const updateFromSelectedNote = async () => {
-			const note = await joplin.workspace.selectedNote();
-			if (!note) return;
-			await editors.postMessage(view, { type: 'setNote', value: { id: note.id, body: note.body }});
-		}
-
-		await editors.onActivationCheck(view, async (event) => {
+	const view = await editors.create("kanbanBoard", {
+		windowId,
+		onActivationCheck: async event => {
 			if (!event.noteId) return false;
 
 			const note = await joplin.data.get([ 'notes', event.noteId ], { fields: ['body'] });
@@ -57,17 +36,63 @@ joplin.plugins.register({
 			const isBoard = noteIsBoard(note?.body ?? '');
 			logger.info('onActivationCheck: Note is board:', isBoard);
 			return isBoard;
-		});
+		},
+	});
+	
+	await editors.setHtml(view, `<div id="root" class="platform-${versionInfo.platform}"></div>`);
+	await editors.addScript(view, './panel.js');
+	await editors.addScript(view, './style/reset.css');
+	await editors.addScript(view, './style/main.css');
+	await editors.addScript(view, './vendor/coloris/coloris.css');
+	await editors.addScript(view, './vendor/coloris/coloris.js');
 
-		await editors.onUpdate(view, async (event) => {
-			logger.info('onUpdate');
-			if (event.noteId) {
-				await editors.postMessage(
-					view,
-					{ type: 'setNote', value: { id: event.noteId, body: event.newBody } },
-					event.windowId,
-				);
-			}
+	const updateFromSelectedNote = async () => {
+		const note = await joplin.workspace.selectedNote(windowId);
+		if (!note) return;
+		await editors.postMessage(view, { type: 'setNote', value: { id: note.id, body: note.body }});
+	}
+
+	await editors.onUpdate(view, async (event) => {
+		logger.info('onUpdate');
+		if (event.noteId) {
+			await editors.postMessage(
+				view,
+				{ type: 'setNote', value: { id: event.noteId, body: event.newBody } },
+			);
+		}
+	});
+
+	const handlers = messageHandlers(view, windowId);
+	await editors.onMessage(view, async (message:IpcMessage) => {
+		// These messages are internal messages sent within the app webview and can be ignored
+		if ((message as any).kind === 'ReturnValueResponse') return;
+
+		logger.info('PostMessagePlugin (Webview): Got message from webview:', message);
+
+		if (message.type === 'isReady') {
+			await updateFromSelectedNote();
+			return;
+		}
+		
+		const messageHandler = handlers[message.type];
+		if (messageHandler) return messageHandler(message);
+
+		logger.warn('Unknown message: ' + JSON.stringify(message));
+	});
+};
+
+joplin.plugins.register({
+	onStart: async function() {
+		await joplin.settings.registerSection(settingSectionName, {
+			label: 'YesYouKan',
+			iconName: 'fas fa-th-list',
+		});
+		await joplin.settings.registerSettings(settingItems);
+
+		await registerEditorPlugin(undefined);
+		joplin.workspace.onWindowOpen(async ({ windowId }) => {
+			logger.info('New window opened', windowId);
+			await registerEditorPlugin(windowId);
 		});
 
 		await joplin.commands.register({
@@ -76,33 +101,15 @@ joplin.plugins.register({
 			execute: async () => {
 				logger.info('Creating new Kanban note...');
 				await joplin.commands.execute('newNote', newNoteBody);
-
+	
 				// Wait for the note to be created and the UI to be updated before showing the
 				// editor
 				setTimeout(async () => {
 					await joplin.commands.execute('showEditorPlugin');
-					await updateFromSelectedNote();
 				}, 200);				
 			},
 		});
-
+	
 		await joplin.views.menuItems.create('createKanbanBoardMenuItem', 'createKanbanBoard', MenuItemLocation.Tools, { accelerator: 'CmdOrCtrl+Alt+Shift+K' });
-
-		editors.onMessage(view, async (message:IpcMessage) => {
-			// These messages are internal messages sent within the app webview and can be ignored
-			if ((message as any).kind === 'ReturnValueResponse') return;
-
-			logger.info('PostMessagePlugin (Webview): Got message from webview:', message);
-
-			if (message.type === 'isReady') {
-				//await updateFromSelectedNote();
-				return;
-			}
-			
-			const messageHandler = messageHandlers[message.type];
-			if (messageHandler) return messageHandler(message);
-
-			logger.warn('Unknown message: ' + JSON.stringify(message));
-		});
 	},
 });


### PR DESCRIPTION
# Summary

This pull request updates the YesYouKan plugin to support secondary windows in Joplin desktop.

Resolves #41.

# Notes

- This change requires a corresponding pull request to be merged into the main Joplin repository.
