### PR TITLE
remove note id, and add parent_id

### DIFF
--- a/src/messageHandlers.ts
+++ b/src/messageHandlers.ts
@@ -150,10 +150,11 @@ const messageHandlers:Record<IpcMessageType, MessageHandler> = {
 
 		const newNote = {
 			...note,
-			id: '',
 			title: note.title + ' - Copy',
 			tags: tagTitles.join(','),
 		};
+		
+		delete newNote.id;
 
 		return await joplin.data.post(['notes'], null, newNote);
 	},

--- a/src/messageHandlers.ts
+++ b/src/messageHandlers.ts
@@ -28,7 +28,7 @@ const setNoteHandler = async (messageNote:Note) => {
 	}
 }
 
-const noteFields = ['id', 'title', 'body', 'todo_due', 'todo_completed', 'is_todo', 'deleted_time'];
+const noteFields = ['id', 'title', 'body', 'todo_due', 'todo_completed', 'is_todo', 'deleted_time', 'parent_id'];
 
 const messageHandlers:Record<IpcMessageType, MessageHandler> = {
 
@@ -150,6 +150,7 @@ const messageHandlers:Record<IpcMessageType, MessageHandler> = {
 
 		const newNote = {
 			...note,
+			id: '',
 			title: note.title + ' - Copy',
 			tags: tagTitles.join(','),
 		};


### PR DESCRIPTION
Fixes #55

- Removes id from duplicate copy of note before being saved.
- Adds parent_id from original note to duplicate copy so that it will be created in the same folder