### PR TITLE
Enhancement: Add plugin setting to determine whether new cards get added to beginning or end of stack

### DIFF
--- a/src/gui/App/App.tsx
+++ b/src/gui/App/App.tsx
@@ -82,6 +82,7 @@ export default () => {
 		setBoard,
 		setDialogConfig,
 		webviewApi,
+		addCardsToBeginningOfStack: effectiveBoardSettings.addCardsToBeginningOfStack,
 	});
 
 	const {

--- a/src/gui/App/hooks/useCardHandler.ts
+++ b/src/gui/App/hooks/useCardHandler.ts
@@ -17,6 +17,7 @@ interface Props {
 	pushUndo: PushUndo;
 	webviewApi: WebviewApi;
 	setDialogConfig: (value: React.SetStateAction<DialogConfig>) => void;
+	addCardsToBeginningOfStack: boolean;
 }
 
 export default (props:Props) => {
@@ -73,14 +74,20 @@ export default (props:Props) => {
 
 		const newBoard = produce(props.board, draft => {
 			const stackIndex = findStackIndex(draft, event.stackId);
-			draft.stacks[stackIndex].cards.push({
+			const newCard = {
 				id: newCardId,
 				title: 'New card',
 				body: '',
 				is_todo: 0,
 				todo_completed: 0,
 				todo_due: 0,
-			});
+			}
+
+			if (props.addCardsToBeginningOfStack) {
+				draft.stacks[stackIndex].cards.unshift(newCard);
+			} else {
+				draft.stacks[stackIndex].cards.push(newCard);
+			}
 		});
 
 		props.setBoard(newBoard);
@@ -127,10 +134,17 @@ export default (props:Props) => {
 
 			const newBoard = produce(props.board, draft => {
 				const newCard = createCard();
-				draft.stacks[stackIndex].cards.push({
-					...newCard,
-					...serializeNoteToCard(newNote),
-				});
+				if (props.addCardsToBeginningOfStack) {
+					draft.stacks[stackIndex].cards.unshift({
+						...newCard,
+						...serializeNoteToCard(newNote),
+					});
+				} else {
+					draft.stacks[stackIndex].cards.push({
+						...newCard,
+						...serializeNoteToCard(newNote),
+					});
+				}
 			});
 
 			props.setBoard(newBoard);
@@ -138,7 +152,11 @@ export default (props:Props) => {
 			props.pushUndo(props.board);
 
 			const newBoard = produce(props.board, draft => {
-				draft.stacks[stackIndex].cards.push(duplicateCard(card));
+				if (props.addCardsToBeginningOfStack) {
+					draft.stacks[stackIndex].cards.unshift(duplicateCard(card));
+				} else {
+					draft.stacks[stackIndex].cards.push(duplicateCard(card));
+				}
 			});
 	
 			props.setBoard(newBoard);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -138,6 +138,7 @@ export interface PluginSettings {
 	lastStackAddedDates?: LastStackAddedDates;
 	archiveNoteId?: string;
 	markAsCompletedLastStackCards?: boolean;
+	addCardsToBeginningOfStack?: boolean;
 }
 
 export interface CardSettings {
@@ -252,6 +253,14 @@ export const pluginSettingItems:PluginSettingItems = {
 		type: SettingItemType.Bool,
 		public: true,
 		value: true,
+		section: settingSectionName,
+	},
+
+	addCardsToBeginningOfStack: {
+		label: 'Add new cards to beginning of stack',
+		type: SettingItemType.Bool,
+		public: true,
+		value: false,
 		section: settingSectionName,
 	},
 };


### PR DESCRIPTION
Fixes #54 

- Adds a new plugin setting to determine whether cards get added to top or bottom of stack.
- The default remains to add new cards to the bottom of the stack.