### PR TITLE
Fixes#100: added customizable card max height and toolbar toggle for card body

### DIFF
--- a/src/gui/App/App.tsx
+++ b/src/gui/App/App.tsx
@@ -211,7 +211,7 @@ export default () => {
 		cssStrings,
 		stackDynamicWidth: effectiveBoardSettings.stackDynamicWidth,
 		stackWidth: effectiveBoardSettings.stackWidth,
-		cardMaxHeight: effectiveBoardSettings.cardMaxHeight ?? 20,
+		cardMaxHeight: effectiveBoardSettings.cardMaxHeight ?? 15,
 	});
 
 	const onFilter = useCallback(() => {

--- a/src/gui/App/App.tsx
+++ b/src/gui/App/App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useCallback, useState, useMemo, useRef, useEffect } from "react";
+import { useCallback, useState, useMemo, useRef, useEffect, useReducer } from "react";
 import { Board, Filters, Note, WebviewApi, emptyBoard, getDefaultFilters } from "../../utils/types";
 import StackViewer, { StackDropEventHandler, StackEvent, StackEventHandler } from "../StackViewer";
 import { DragDropContext, Droppable, OnDragEndResponder } from "@hello-pangea/dnd";
@@ -198,11 +198,20 @@ export default () => {
 		webviewApi,
 	});
 
+	const [showCardBody, toggleShowCardBody] = useReducer((prev) => !prev, effectiveBoardSettings.showCardBody !== false);
+
+	useEffect(() => {
+		if (effectiveBoardSettings.showCardBody !== undefined && effectiveBoardSettings.showCardBody !== showCardBody) {
+			toggleShowCardBody();
+		}
+	}, [effectiveBoardSettings.showCardBody]);
+
 	const appStyle = useStyle({
 		backgroundColors,
 		cssStrings,
 		stackDynamicWidth: effectiveBoardSettings.stackDynamicWidth,
 		stackWidth: effectiveBoardSettings.stackWidth,
+		cardMaxHeight: effectiveBoardSettings.cardMaxHeight ?? 20,
 	});
 
 	const onFilter = useCallback(() => {
@@ -218,6 +227,8 @@ export default () => {
 		onRedoBoard,
 		onUndoBoard,
 		onFilter,
+		onToggleShowCardBody: toggleShowCardBody,
+		showCardBody,
 	});
 
 	const cardTags = useCardTags({ board });
@@ -252,7 +263,7 @@ export default () => {
 				onDeleteCard={onDeleteCard}
 				onDuplicateCard={onDuplicateCard}
 				onEditSettings={onEditStackSettings}
-				showCardBody={effectiveBoardSettings.showCardBody}
+				showCardBody={showCardBody}
 				onDrop={onStackDrop}
 				isLast={index === board.stacks.length - 1}
 				dynamicWidth={dynamicWidth}

--- a/src/gui/App/hooks/useStyle.ts
+++ b/src/gui/App/hooks/useStyle.ts
@@ -4,6 +4,7 @@ import { Colors, colorsToCss } from "../../../utils/colors";
 interface Props {
 	stackDynamicWidth: boolean;
 	stackWidth: number;
+	cardMaxHeight: number;
 	backgroundColors: Colors;
 	cssStrings: string[];
 }
@@ -30,12 +31,26 @@ export default (props:Props) => {
 			`);
 		}
 
+		if (props.cardMaxHeight > 0) {
+			styles.push(`
+				.card {
+					max-height: ${props.cardMaxHeight}em;
+				}
+			`);
+		} else {
+			styles.push(`
+				.card {
+					max-height: none;
+				}
+			`);
+		}
+
 		styles.push(colorsToCss(props.backgroundColors, 'background', 'background-color'));
 
 		styles.push(props.cssStrings.join('\n'));
 
 		return styles.join('\n\n');
-	}, [props.stackDynamicWidth, props.stackWidth, props.backgroundColors, props.cssStrings]);
+	}, [props.stackDynamicWidth, props.stackWidth, props.cardMaxHeight, props.backgroundColors, props.cssStrings]);
 
 	return appStyle;
 }

--- a/src/gui/App/hooks/useToolbarButtons.ts
+++ b/src/gui/App/hooks/useToolbarButtons.ts
@@ -8,6 +8,8 @@ interface Props {
 	onRedoBoard: () => void;
 	onAddStack: () => void;
 	onFilter: () => void;
+	onToggleShowCardBody: () => void;
+	showCardBody: boolean;
 	filterTotalCardCount: number;
 	filterVisibleCardCount: number;
 }
@@ -55,9 +57,18 @@ export default (props:Props) => {
 					props.onFilter();
 				},
 			},
+
+			{
+				name: 'toggleCardBody',
+				icon: props.showCardBody ? 'eye' : 'eye-slash',
+				title: props.showCardBody ? 'Hide card body' : 'Show card body',
+				onClick: () => {
+					props.onToggleShowCardBody();
+				},
+			},
 		];		
 		return output;
-	}, [props.onUndoBoard, props.onRedoBoard, props.historyUndoLength, props.historyRedoLength, props.onAddStack, props.onFilter, props.filterTotalCardCount, props.filterVisibleCardCount]);
+	}, [props.onUndoBoard, props.onRedoBoard, props.historyUndoLength, props.historyRedoLength, props.onAddStack, props.onFilter, props.filterTotalCardCount, props.filterVisibleCardCount, props.onToggleShowCardBody, props.showCardBody]);
 
 	return toolbarButtons;
 }

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -199,7 +199,6 @@ ul, ol {
 	border: 1px solid var(--joplin-divider-color);
 	border-radius: 8px;
 	box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px;
-	max-height: 20em;
 	overflow: hidden;
 
 	> .content {

--- a/src/utils/setupFontAwesome.ts
+++ b/src/utils/setupFontAwesome.ts
@@ -1,5 +1,5 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faTimes, faEllipsisV, faPlus, faUndo, faRedo, faRotateLeft, faClock, faTriangleExclamation, faFilter } from '@fortawesome/free-solid-svg-icons';
+import { faTimes, faEllipsisV, faPlus, faUndo, faRedo, faRotateLeft, faClock, faTriangleExclamation, faFilter, faEye, faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle } from '@fortawesome/free-regular-svg-icons';
 
 export default () => {
@@ -14,5 +14,7 @@ export default () => {
 		faClock,
 		faTriangleExclamation,
 		faFilter,
+		faEye,
+		faEyeSlash,
 	);
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -151,6 +151,7 @@ export interface PluginSettings {
 	showCardBody?: boolean;
 	cardInsertLocation?: CardInsertLocation;
 	showCardCounter?: boolean;
+	cardMaxHeight?: number;
 }
 
 export interface CardSettings {
@@ -316,6 +317,15 @@ export const pluginSettingItems:PluginSettingItems = {
 		type: SettingItemType.Bool,
 		public: true,
 		value: true,
+		section: settingSectionName,
+	},
+
+	cardMaxHeight: {
+		label: 'Card maximum height (em)',
+		description: 'Maximum height of a card in em units. Set to 0 for no limit.',
+		type: SettingItemType.Int,
+		public: true,
+		value: 20,
 		section: settingSectionName,
 	},
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -325,7 +325,7 @@ export const pluginSettingItems:PluginSettingItems = {
 		description: 'Maximum height of a card in em units. Set to 0 for no limit.',
 		type: SettingItemType.Int,
 		public: true,
-		value: 20,
+		value: 15,
 		section: settingSectionName,
 	},
 };


### PR DESCRIPTION
Fixes #100

Changes

- Added a new plugin setting **"Card maximum height (em)"** (default: 15)
- Added a **toggle button** (eye icon) in the kanban toolbar to show/hide card body without going to plugin settings

Files changed

- `types.ts`: added `cardMaxHeight` setting
- `main.css` : removed hardcoded `max-height: 20em`
- `useStyle.ts` : applies card max height dynamically from setting
- `useToolbarButtons.ts` : added eye/eye-slash toggle button
- `App.tsx` : wired up both features
- `setupFontAwesome.ts` : registered eye icons

Screen recording:

[Screencast from 2026-04-09 12-57-18.webm](https://github.com/user-attachments/assets/d559e865-74fa-409e-afc9-2cd127ca0cb2)
